### PR TITLE
Replace regex with wildmatch, add missing features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,81 @@
 # gitignore
 
-A Go library for matching paths against gitignore rules. Handles the full gitignore spec including negation patterns, `**` globs, bracket expressions with POSIX character classes, directory-only patterns, and scoped patterns from nested `.gitignore` files.
+A standalone Go library for matching paths against gitignore rules. Built to replace go-git's broken gitignore matcher with something that actually passes git's own wildmatch test suite.
+
+Pattern matching uses a direct wildmatch implementation (two-pointer backtracking, same algorithm as git's wildmatch.c) rather than compiling patterns to regexes. This gets you correct bracket expressions, POSIX character classes, proper `**` handling, and about 10-20x better performance than regex-based approaches.
+
+Handles the full gitignore spec: negation patterns, `**` globs, bracket expressions with POSIX character classes, directory-only patterns, escaped characters, `core.excludesfile`, and scoped patterns from nested `.gitignore` files.
 
 ```go
 import "github.com/git-pkgs/gitignore"
-
-// Load patterns from .git/info/exclude and root .gitignore
-m := gitignore.New("/path/to/repo")
-
-// Add patterns from nested .gitignore files
-m.AddFromFile("/path/to/repo/src/.gitignore", "src")
-
-// Or add patterns directly
-m.AddPatterns([]byte("*.log\nbuild/\n"), "")
-
-// Check if a path is ignored (use trailing slash for directories)
-m.Match("vendor/lib.go")  // true if matched
-m.Match("vendor/")        // tests as directory
 ```
 
-Paths passed to `Match` should use forward slashes and be relative to the repository root. Directory paths need a trailing slash so that directory-only patterns (written with a trailing `/` in `.gitignore`) work correctly.
+## Loading patterns
 
-Uses last-match-wins semantics, same as git.
+`New` reads the user's global excludes file, `.git/info/exclude`, and the root `.gitignore`:
+
+```go
+m := gitignore.New("/path/to/repo")
+m.Match("vendor/lib.go")  // true if matched
+m.Match("vendor/")        // trailing slash tests as directory
+```
+
+For repos with nested `.gitignore` files, `NewFromDirectory` walks the tree and loads them all, scoped to their containing directory:
+
+```go
+m := gitignore.NewFromDirectory("/path/to/repo")
+```
+
+You can also add patterns manually:
+
+```go
+m.AddFromFile("/path/to/repo/src/.gitignore", "src")
+m.AddPatterns([]byte("*.log\nbuild/\n"), "")
+```
+
+## Matching
+
+`Match` uses the trailing-slash convention to distinguish files from directories. If you already know whether the path is a directory, `MatchPath` avoids that:
+
+```go
+m.Match("vendor/")             // directory
+m.MatchPath("vendor", true)    // same thing, no trailing slash needed
+```
+
+To find out which pattern matched (useful for debugging), use `MatchDetail`:
+
+```go
+r := m.MatchDetail("app.log")
+if r.Matched {
+    fmt.Printf("ignored by %s (line %d of %s)\n", r.Pattern, r.Line, r.Source)
+}
+```
+
+## Walking a directory tree
+
+`Walk` traverses the repo, loading `.gitignore` files as it descends and skipping ignored entries. It never descends into `.git` or ignored directories.
+
+```go
+gitignore.Walk("/path/to/repo", func(path string, d fs.DirEntry) error {
+    fmt.Println(path)
+    return nil
+})
+```
+
+## Error handling
+
+Invalid patterns (like unknown POSIX character classes) are silently skipped during matching. To inspect them:
+
+```go
+for _, err := range m.Errors() {
+    fmt.Println(err) // includes source file, line number, and reason
+}
+```
+
+## Thread safety
+
+A Matcher is safe for concurrent `Match`/`MatchPath`/`MatchDetail` calls once construction is complete. Don't call `AddPatterns` or `AddFromFile` concurrently with matching.
+
+## Match semantics
+
+Paths should use forward slashes and be relative to the repository root. Last-match-wins, same as git.

--- a/gitignore_bench_test.go
+++ b/gitignore_bench_test.go
@@ -1,0 +1,113 @@
+package gitignore_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/git-pkgs/gitignore"
+)
+
+func benchMatcher(b *testing.B, patterns string) *gitignore.Matcher {
+	b.Helper()
+	root := b.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git", "info"), 0755); err != nil {
+		b.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(patterns), 0644); err != nil {
+		b.Fatal(err)
+	}
+	return gitignore.New(root)
+}
+
+func realisticPatterns() string {
+	var b strings.Builder
+	// Extensions
+	exts := []string{"log", "tmp", "bak", "swp", "swo", "o", "a", "so", "dylib",
+		"pyc", "pyo", "class", "jar", "war", "ear", "dll", "exe", "obj", "lib",
+		"out", "app", "DS_Store", "thumbs.db", "desktop.ini", "iml", "ipr", "iws"}
+	for _, ext := range exts {
+		fmt.Fprintf(&b, "*.%s\n", ext)
+	}
+	// Directories
+	dirs := []string{"node_modules/", "vendor/", "build/", "dist/", "target/",
+		".cache/", ".tmp/", "__pycache__/", ".pytest_cache/", "coverage/",
+		".nyc_output/", ".next/", ".nuxt/", ".output/", ".vscode/", ".idea/",
+		".gradle/", ".mvn/", "bin/", "obj/"}
+	for _, d := range dirs {
+		b.WriteString(d)
+		b.WriteByte('\n')
+	}
+	// Doublestar patterns
+	dsPats := []string{"**/logs/**", "**/.env", "**/.env.*", "**/secret*",
+		"**/credentials.*", "**/*.min.js", "**/*.min.css", "**/*.map"}
+	for _, p := range dsPats {
+		b.WriteString(p)
+		b.WriteByte('\n')
+	}
+	// Negation
+	b.WriteString("!.env.example\n")
+	b.WriteString("!important.log\n")
+	// Anchored
+	b.WriteString("/Makefile.local\n")
+	b.WriteString("/config/local.yml\n")
+	// Bracket
+	b.WriteString("*.[oa]\n")
+	b.WriteString("*~\n")
+	b.WriteString(".*.sw[a-p]\n")
+	return b.String()
+}
+
+func BenchmarkCompile(b *testing.B) {
+	patterns := realisticPatterns()
+	root := b.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git", "info"), 0755); err != nil {
+		b.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(patterns), 0644); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for b.Loop() {
+		gitignore.New(root)
+	}
+}
+
+func BenchmarkMatchHit(b *testing.B) {
+	m := benchMatcher(b, realisticPatterns())
+	b.ResetTimer()
+	for b.Loop() {
+		m.Match("src/app.log")
+	}
+}
+
+func BenchmarkMatchMiss(b *testing.B) {
+	m := benchMatcher(b, realisticPatterns())
+	b.ResetTimer()
+	for b.Loop() {
+		m.Match("src/main.go")
+	}
+}
+
+func BenchmarkMatchLargePatternSet(b *testing.B) {
+	var sb strings.Builder
+	sb.WriteString(realisticPatterns())
+	for i := range 200 {
+		fmt.Fprintf(&sb, "pattern_%d_*.txt\n", i)
+	}
+	m := benchMatcher(b, sb.String())
+	b.ResetTimer()
+	for b.Loop() {
+		m.Match("src/components/Button.tsx")
+	}
+}
+
+func BenchmarkMatchDeepPath(b *testing.B) {
+	m := benchMatcher(b, realisticPatterns())
+	b.ResetTimer()
+	for b.Loop() {
+		m.Match("a/b/c/d/e/f/g/file.txt")
+	}
+}

--- a/wildmatch.go
+++ b/wildmatch.go
@@ -1,0 +1,228 @@
+package gitignore
+
+// matchSegments matches path segments against pattern segments using two-pointer
+// backtracking. A doubleStar segment matches zero or more path segments.
+func matchSegments(patSegs []segment, pathSegs []string) bool {
+	px, tx := 0, 0
+	// Backtrack point for the most recent ** we passed.
+	starPx, starTx := -1, -1
+
+	for tx < len(pathSegs) {
+		if px < len(patSegs) && patSegs[px].doubleStar {
+			// Save backtrack point: try matching zero path segments first.
+			starPx = px
+			starTx = tx
+			px++
+			continue
+		}
+		if px < len(patSegs) && !patSegs[px].doubleStar && matchSegment(patSegs[px].raw, pathSegs[tx]) {
+			px++
+			tx++
+			continue
+		}
+		// Mismatch. Backtrack: consume one more path segment with the last **.
+		if starPx >= 0 {
+			starTx++
+			tx = starTx
+			px = starPx + 1
+			continue
+		}
+		return false
+	}
+
+	// Remaining pattern segments must all be ** to match.
+	for px < len(patSegs) {
+		if !patSegs[px].doubleStar {
+			return false
+		}
+		px++
+	}
+	return true
+}
+
+// matchSegment matches a single path component against a glob pattern segment.
+// Handles *, ?, [...], and \-escapes. Uses two-pointer backtracking for *.
+func matchSegment(glob, text string) bool {
+	gx, tx := 0, 0
+	starGx, starTx := -1, -1
+
+	for tx < len(text) {
+		if gx < len(glob) {
+			ch := glob[gx]
+			switch {
+			case ch == '\\' && gx+1 < len(glob):
+				// Escaped character: match literally.
+				gx++
+				if text[tx] == glob[gx] {
+					gx++
+					tx++
+					continue
+				}
+			case ch == '?':
+				gx++
+				tx++
+				continue
+			case ch == '*':
+				// Save backtrack point and try matching zero chars.
+				starGx = gx
+				starTx = tx
+				gx++
+				continue
+			case ch == '[':
+				matched, newGx, ok := matchBracket(glob, gx, text[tx])
+				if ok && matched {
+					gx = newGx
+					tx++
+					continue
+				}
+				if !ok && text[tx] == '[' {
+					// Invalid bracket (no closing ]); treat [ as literal.
+					gx++
+					tx++
+					continue
+				}
+			default:
+				if text[tx] == ch {
+					gx++
+					tx++
+					continue
+				}
+			}
+		}
+
+		// Mismatch. Backtrack if we have a saved *.
+		if starGx >= 0 {
+			starTx++
+			tx = starTx
+			gx = starGx + 1
+			continue
+		}
+		return false
+	}
+
+	// Consume trailing *'s in the pattern.
+	for gx < len(glob) && glob[gx] == '*' {
+		gx++
+	}
+	return gx == len(glob)
+}
+
+// matchBracket checks if byte ch matches the bracket expression starting at
+// glob[pos] (the '['). Returns (matched, posAfterBracket, valid).
+// If the bracket has no closing ']', valid is false.
+func matchBracket(glob string, pos int, ch byte) (bool, int, bool) {
+	i := pos + 1 // skip opening [
+	if i >= len(glob) {
+		return false, 0, false
+	}
+
+	negate := false
+	if glob[i] == '!' || glob[i] == '^' {
+		negate = true
+		i++
+	}
+
+	matched := false
+	first := true // ] is literal when it's the first char after [, [!, or [^
+
+	for i < len(glob) {
+		if glob[i] == ']' && !first {
+			// End of bracket expression.
+			if negate {
+				matched = !matched
+			}
+			return matched, i + 1, true
+		}
+		first = false
+
+		// POSIX character class: [:name:]
+		if glob[i] == '[' && i+1 < len(glob) && glob[i+1] == ':' {
+			end := findPosixClassEnd(glob, i+2)
+			if end >= 0 {
+				name := glob[i+2 : end]
+				if matchPosixClass(name, ch) {
+					matched = true
+				}
+				i = end + 2 // skip past :]
+				continue
+			}
+			// No closing :], treat [ as literal.
+		}
+
+		// Resolve the current character (possibly escaped).
+		var lo byte
+		if glob[i] == '\\' && i+1 < len(glob) {
+			i++
+			lo = glob[i]
+		} else {
+			lo = glob[i]
+		}
+		i++
+
+		// Check for range: lo-hi
+		if i+1 < len(glob) && glob[i] == '-' && glob[i+1] != ']' {
+			i++ // skip -
+			var hi byte
+			if glob[i] == '\\' && i+1 < len(glob) {
+				i++
+				hi = glob[i]
+			} else {
+				hi = glob[i]
+			}
+			i++
+			if ch >= lo && ch <= hi {
+				matched = true
+			}
+		} else {
+			if ch == lo {
+				matched = true
+			}
+		}
+	}
+
+	// No closing ] found.
+	return false, 0, false
+}
+
+// findPosixClassEnd finds the position of ':' in ":]" after startPos.
+// Returns -1 if not found.
+func findPosixClassEnd(glob string, startPos int) int {
+	for i := startPos; i+1 < len(glob); i++ {
+		if glob[i] == ':' && glob[i+1] == ']' {
+			return i
+		}
+	}
+	return -1
+}
+
+// matchPosixClass checks whether byte ch belongs to the named POSIX character class.
+func matchPosixClass(name string, ch byte) bool {
+	switch name {
+	case "alnum":
+		return ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch >= '0' && ch <= '9'
+	case "alpha":
+		return ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z'
+	case "blank":
+		return ch == ' ' || ch == '\t'
+	case "cntrl":
+		return ch < 0x20 || ch == 0x7f
+	case "digit":
+		return ch >= '0' && ch <= '9'
+	case "graph":
+		return ch > 0x20 && ch < 0x7f
+	case "lower":
+		return ch >= 'a' && ch <= 'z'
+	case "print":
+		return ch >= 0x20 && ch < 0x7f
+	case "punct":
+		return ch > 0x20 && ch < 0x7f &&
+			(ch < 'a' || ch > 'z') && (ch < 'A' || ch > 'Z') && (ch < '0' || ch > '9')
+	case "space":
+		return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '\f' || ch == '\v'
+	case "upper":
+		return ch >= 'A' && ch <= 'Z'
+	case "xdigit":
+		return ch >= '0' && ch <= '9' || ch >= 'a' && ch <= 'f' || ch >= 'A' && ch <= 'F'
+	}
+	return false
+}


### PR DESCRIPTION
Replace the regex matching engine with a direct wildmatch implementation (same algorithm as git's wildmatch.c). Fix trimTrailingSpaces bugs. Add core.excludesfile support, automatic nested .gitignore discovery, match provenance, error reporting, and pattern indexing.

- Fix trimTrailingSpaces: was using TrimLeft, stripping tabs, mishandling escaped spaces
- Add benchmarks for compile and match operations
- Replace regex with two-pointer backtracking wildmatch (9-19x faster matching)
- Add core.excludesfile support (global gitignore)
- Add NewFromDirectory and Walk for automatic .gitignore discovery
- Document thread safety on Matcher
- Add MatchPath(path, isDir) to avoid trailing slash convention
- Surface parse errors via Errors() method
- Add MatchDetail for match provenance (which pattern matched, source file, line number)
- Add literal suffix indexing for fast pattern rejection (another 2-3x on top)