### PR TITLE
Add WalkFrom to walk a subdirectory with correct root-level ignore rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ gitignore.Walk("/path/to/repo", func(path string, d fs.DirEntry) error {
 })
 ```
 
+`WalkFrom` walks a subdirectory while still respecting root-level rules. It loads global excludes, `.git/info/exclude`, the root `.gitignore`, and every `.gitignore` between the root and the start directory before walking, so patterns scoped above the start still apply. Paths passed to `fn` are relative to the root.
+
+```go
+gitignore.WalkFrom("/path/to/repo", "src/pkg", func(path string, d fs.DirEntry) error {
+    fmt.Println(path) // e.g. "src/pkg/lib.go"
+    return nil
+})
+```
+
 ## Error handling
 
 Invalid patterns (like unknown POSIX character classes) are silently skipped during matching. To inspect them:

--- a/gitignore.go
+++ b/gitignore.go
@@ -196,35 +196,43 @@ func Walk(root string, fn func(path string, d fs.DirEntry) error) error {
 // walk begins. Any .gitignore files between root and start are loaded
 // before the walk begins, so their patterns apply correctly.
 //
-// The start parameter is a slash-separated path relative to root (e.g.
-// "src/pkg"). Paths passed to fn are relative to root (not to start)
-// and use the OS path separator. The start directory itself is passed
-// to fn.
+// The start parameter is a path relative to root (e.g. "src/pkg"),
+// using either forward slashes or the OS path separator. Paths passed
+// to fn are relative to root (not to start) and use the OS path
+// separator. The start directory itself is passed to fn.
 func WalkFrom(root, start string, fn func(path string, d fs.DirEntry) error) error {
 	if start == "" || start == "." {
 		return Walk(root, fn)
 	}
 
-	start = filepath.ToSlash(filepath.Clean(start))
+	start = filepath.Clean(start)
 
 	m := New(root)
 
-	parts := strings.Split(start, "/")
-	for i := range parts {
-		prefix := strings.Join(parts[:i+1], "/")
-		igPath := filepath.Join(root, filepath.FromSlash(prefix), ".gitignore")
+	{
+		slashed := filepath.ToSlash(start)
+		for i := 0; i < len(slashed); i++ {
+			if slashed[i] == '/' {
+				prefix := slashed[:i]
+				igPath := filepath.Join(root, prefix, ".gitignore")
+				if _, err := os.Stat(igPath); err == nil {
+					m.AddFromFile(igPath, prefix)
+				}
+			}
+		}
+		igPath := filepath.Join(root, start, ".gitignore")
 		if _, err := os.Stat(igPath); err == nil {
-			m.AddFromFile(igPath, prefix)
+			m.AddFromFile(igPath, slashed)
 		}
 	}
 
-	startAbs := filepath.Join(root, filepath.FromSlash(start))
-	info, err := os.Stat(startAbs)
+	startDir := filepath.Join(root, start)
+	info, err := os.Stat(startDir)
 	if err != nil {
 		return err
 	}
 
-	startRel := filepath.FromSlash(start)
+	startRel := start
 	if fn != nil {
 		if err := fn(startRel, fs.FileInfoToDirEntry(info)); err != nil {
 			return err

--- a/gitignore.go
+++ b/gitignore.go
@@ -219,10 +219,7 @@ func WalkFrom(root, start string, fn func(path string, d fs.DirEntry) error) err
 				break
 			}
 			prefix := slashed[:off+i]
-			igPath := filepath.Join(root, prefix, ".gitignore")
-			if _, err := os.Stat(igPath); err == nil {
-				m.AddFromFile(igPath, prefix)
-			}
+			m.AddFromFile(filepath.Join(root, prefix, ".gitignore"), prefix)
 			off += i + 1
 		}
 	}

--- a/gitignore.go
+++ b/gitignore.go
@@ -206,6 +206,9 @@ func WalkFrom(root, start string, fn func(path string, d fs.DirEntry) error) err
 	}
 
 	start = filepath.Clean(start)
+	if start == "." {
+		return Walk(root, fn)
+	}
 
 	m := New(root)
 

--- a/gitignore.go
+++ b/gitignore.go
@@ -209,15 +209,13 @@ func WalkFrom(root, start string, fn func(path string, d fs.DirEntry) error) err
 
 	m := New(root)
 
+	// Load .gitignore from each ancestor directory between root and start
+	// (exclusive of start itself, which walkRecursive loads).
 	{
 		slashed := filepath.ToSlash(start)
 		for off := 0; ; {
 			i := strings.IndexByte(slashed[off:], '/')
 			if i == -1 {
-				igPath := filepath.Join(root, start, ".gitignore")
-				if _, err := os.Stat(igPath); err == nil {
-					m.AddFromFile(igPath, slashed)
-				}
 				break
 			}
 			prefix := slashed[:off+i]

--- a/gitignore.go
+++ b/gitignore.go
@@ -211,18 +211,21 @@ func WalkFrom(root, start string, fn func(path string, d fs.DirEntry) error) err
 
 	{
 		slashed := filepath.ToSlash(start)
-		for i := 0; i < len(slashed); i++ {
-			if slashed[i] == '/' {
-				prefix := slashed[:i]
-				igPath := filepath.Join(root, prefix, ".gitignore")
+		for off := 0; ; {
+			i := strings.IndexByte(slashed[off:], '/')
+			if i == -1 {
+				igPath := filepath.Join(root, start, ".gitignore")
 				if _, err := os.Stat(igPath); err == nil {
-					m.AddFromFile(igPath, prefix)
+					m.AddFromFile(igPath, slashed)
 				}
+				break
 			}
-		}
-		igPath := filepath.Join(root, start, ".gitignore")
-		if _, err := os.Stat(igPath); err == nil {
-			m.AddFromFile(igPath, slashed)
+			prefix := slashed[:off+i]
+			igPath := filepath.Join(root, prefix, ".gitignore")
+			if _, err := os.Stat(igPath); err == nil {
+				m.AddFromFile(igPath, prefix)
+			}
+			off += i + 1
 		}
 	}
 
@@ -232,14 +235,13 @@ func WalkFrom(root, start string, fn func(path string, d fs.DirEntry) error) err
 		return err
 	}
 
-	startRel := start
 	if fn != nil {
-		if err := fn(startRel, fs.FileInfoToDirEntry(info)); err != nil {
+		if err := fn(start, fs.FileInfoToDirEntry(info)); err != nil {
 			return err
 		}
 	}
 
-	return walkRecursive(root, startRel, m, fn)
+	return walkRecursive(root, start, m, fn)
 }
 
 func walkRecursive(root, rel string, m *Matcher, fn func(string, fs.DirEntry) error) error {

--- a/gitignore.go
+++ b/gitignore.go
@@ -189,6 +189,51 @@ func Walk(root string, fn func(path string, d fs.DirEntry) error) error {
 	return walkRecursive(root, "", m, fn)
 }
 
+// WalkFrom walks the directory tree starting at a subdirectory of root,
+// calling fn for each file and directory that is not ignored by gitignore
+// rules. Unlike Walk, it separates the repository root (used to find
+// .git/info/exclude and the root .gitignore) from the directory where the
+// walk begins. Any .gitignore files between root and start are loaded
+// before the walk begins, so their patterns apply correctly.
+//
+// The start parameter is a slash-separated path relative to root (e.g.
+// "src/pkg"). Paths passed to fn are relative to root (not to start)
+// and use the OS path separator. The start directory itself is passed
+// to fn.
+func WalkFrom(root, start string, fn func(path string, d fs.DirEntry) error) error {
+	if start == "" || start == "." {
+		return Walk(root, fn)
+	}
+
+	start = filepath.ToSlash(filepath.Clean(start))
+
+	m := New(root)
+
+	parts := strings.Split(start, "/")
+	for i := range parts {
+		prefix := strings.Join(parts[:i+1], "/")
+		igPath := filepath.Join(root, filepath.FromSlash(prefix), ".gitignore")
+		if _, err := os.Stat(igPath); err == nil {
+			m.AddFromFile(igPath, prefix)
+		}
+	}
+
+	startAbs := filepath.Join(root, filepath.FromSlash(start))
+	info, err := os.Stat(startAbs)
+	if err != nil {
+		return err
+	}
+
+	startRel := filepath.FromSlash(start)
+	if fn != nil {
+		if err := fn(startRel, fs.FileInfoToDirEntry(info)); err != nil {
+			return err
+		}
+	}
+
+	return walkRecursive(root, startRel, m, fn)
+}
+
 func walkRecursive(root, rel string, m *Matcher, fn func(string, fs.DirEntry) error) error {
 	dir := root
 	if rel != "" {

--- a/gitignore_test.go
+++ b/gitignore_test.go
@@ -2638,6 +2638,42 @@ func TestWalkFromLoadsIntermediateGitignore(t *testing.T) {
 	}
 }
 
+func TestWalkFromLoadsStartDirGitignore(t *testing.T) {
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git", "info"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "src", "pkg"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "src", "pkg", ".gitignore"), []byte("*.out\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"src/pkg/lib.go", "src/pkg/build.out"} {
+		if err := os.WriteFile(filepath.Join(root, f), []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := make(map[string]bool)
+	err := gitignore.WalkFrom(root, "src/pkg", func(path string, d os.DirEntry) error {
+		got[filepath.ToSlash(path)] = true
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !got["src/pkg/lib.go"] {
+		t.Error("WalkFrom should yield src/pkg/lib.go")
+	}
+	if got["src/pkg/build.out"] {
+		t.Error("WalkFrom should not yield src/pkg/build.out (ignored by src/pkg/.gitignore)")
+	}
+}
+
 func TestWalkFromLoadsGitInfoExclude(t *testing.T) {
 	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
 

--- a/gitignore_test.go
+++ b/gitignore_test.go
@@ -2721,41 +2721,45 @@ func TestWalkFromLoadsGitInfoExclude(t *testing.T) {
 	}
 }
 
-func TestWalkFromEmptyStart(t *testing.T) {
-	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+func TestWalkFromRootEquivalentStart(t *testing.T) {
+	for _, start := range []string{"", ".", "./", "./."} {
+		t.Run("start="+start, func(t *testing.T) {
+			t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
 
-	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, ".git", "info"), 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("*.log\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "file.txt"), []byte("x"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "trace.log"), []byte("x"), 0644); err != nil {
-		t.Fatal(err)
-	}
+			root := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(root, ".git", "info"), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("*.log\n"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(root, "file.txt"), []byte("x"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(root, "trace.log"), []byte("x"), 0644); err != nil {
+				t.Fatal(err)
+			}
 
-	var collected []string
-	err := gitignore.WalkFrom(root, "", func(path string, d os.DirEntry) error {
-		collected = append(collected, filepath.ToSlash(path))
-		return nil
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+			var collected []string
+			err := gitignore.WalkFrom(root, start, func(path string, d os.DirEntry) error {
+				collected = append(collected, filepath.ToSlash(path))
+				return nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	got := make(map[string]bool)
-	for _, p := range collected {
-		got[p] = true
-	}
+			got := make(map[string]bool)
+			for _, p := range collected {
+				got[p] = true
+			}
 
-	if !got["file.txt"] {
-		t.Error("WalkFrom with empty start should yield file.txt")
-	}
-	if got["trace.log"] {
-		t.Error("WalkFrom with empty start should not yield trace.log")
+			if !got["file.txt"] {
+				t.Errorf("WalkFrom(start=%q) should yield file.txt", start)
+			}
+			if got["trace.log"] {
+				t.Errorf("WalkFrom(start=%q) should not yield trace.log", start)
+			}
+		})
 	}
 }

--- a/gitignore_test.go
+++ b/gitignore_test.go
@@ -2523,3 +2523,203 @@ func TestNewEmptyRootSkipsFilesystem(t *testing.T) {
 		t.Error("AddPatterns(*.tmp) should still work after New(\"\")")
 	}
 }
+
+func TestWalkFrom(t *testing.T) {
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git", "info"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("*.log\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, dir := range []string{"src", "src/pkg", "src/pkg/internal", "docs"} {
+		if err := os.MkdirAll(filepath.Join(root, dir), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, f := range []string{
+		"README.md",
+		"src/main.go",
+		"src/debug.log",
+		"src/pkg/lib.go",
+		"src/pkg/internal/helper.go",
+		"src/pkg/internal/trace.log",
+		"docs/guide.md",
+	} {
+		if err := os.WriteFile(filepath.Join(root, f), []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var collected []string
+	err := gitignore.WalkFrom(root, "src/pkg", func(path string, d os.DirEntry) error {
+		collected = append(collected, filepath.ToSlash(path))
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := make(map[string]bool)
+	for _, p := range collected {
+		got[p] = true
+	}
+
+	for _, want := range []string{
+		"src/pkg",
+		"src/pkg/lib.go",
+		"src/pkg/internal",
+		"src/pkg/internal/helper.go",
+	} {
+		if !got[want] {
+			t.Errorf("WalkFrom missing expected path %q", want)
+		}
+	}
+	for _, noWant := range []string{
+		"README.md",
+		"src/main.go",
+		"docs/guide.md",
+		"src/pkg/internal/trace.log",
+		"src/debug.log",
+	} {
+		if got[noWant] {
+			t.Errorf("WalkFrom should not yield %q", noWant)
+		}
+	}
+}
+
+func TestWalkFromLoadsIntermediateGitignore(t *testing.T) {
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git", "info"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, dir := range []string{"src", "src/pkg"} {
+		if err := os.MkdirAll(filepath.Join(root, dir), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "src", ".gitignore"), []byte("*.tmp\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"src/pkg/lib.go", "src/pkg/cache.tmp"} {
+		if err := os.WriteFile(filepath.Join(root, f), []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var collected []string
+	err := gitignore.WalkFrom(root, "src/pkg", func(path string, d os.DirEntry) error {
+		collected = append(collected, filepath.ToSlash(path))
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := make(map[string]bool)
+	for _, p := range collected {
+		got[p] = true
+	}
+
+	if !got["src/pkg/lib.go"] {
+		t.Error("WalkFrom should yield src/pkg/lib.go")
+	}
+	if got["src/pkg/cache.tmp"] {
+		t.Error("WalkFrom should not yield src/pkg/cache.tmp (ignored by src/.gitignore)")
+	}
+}
+
+func TestWalkFromLoadsGitInfoExclude(t *testing.T) {
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git", "info"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".git", "info", "exclude"), []byte("secret\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, dir := range []string{"sub"} {
+		if err := os.MkdirAll(filepath.Join(root, dir), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, f := range []string{"sub/visible.txt", "sub/secret"} {
+		if err := os.WriteFile(filepath.Join(root, f), []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var collected []string
+	err := gitignore.WalkFrom(root, "sub", func(path string, d os.DirEntry) error {
+		collected = append(collected, filepath.ToSlash(path))
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := make(map[string]bool)
+	for _, p := range collected {
+		got[p] = true
+	}
+
+	if !got["sub/visible.txt"] {
+		t.Error("WalkFrom should yield sub/visible.txt")
+	}
+	if got["sub/secret"] {
+		t.Error("WalkFrom should not yield sub/secret (ignored by .git/info/exclude)")
+	}
+}
+
+func TestWalkFromEmptyStart(t *testing.T) {
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git", "info"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("*.log\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "file.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "trace.log"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var collected []string
+	err := gitignore.WalkFrom(root, "", func(path string, d os.DirEntry) error {
+		collected = append(collected, filepath.ToSlash(path))
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := make(map[string]bool)
+	for _, p := range collected {
+		got[p] = true
+	}
+
+	if !got["file.txt"] {
+		t.Error("WalkFrom with empty start should yield file.txt")
+	}
+	if got["trace.log"] {
+		t.Error("WalkFrom with empty start should not yield trace.log")
+	}
+}


### PR DESCRIPTION
`Walk` uses its single argument as both the repository root and the walk starting directory, so walking a subdirectory misses `.git/info/exclude` and the root `.gitignore`.

`WalkFrom(root, start, fn)` separates these two concerns. It builds the `Matcher` from `root` (picking up global excludes, `.git/info/exclude`, and the root `.gitignore`), loads any `.gitignore` files between `root` and `start`, then walks from `start` downward. The `start` parameter is a path relative to `root`, accepting either forward slashes or the OS path separator. Any value that cleans to `"."` (including `""` and `"."`) falls back to `Walk`.

Closes #9