### PR TITLE
Avoid per-match allocations in matchPattern and walkRecursive

### DIFF
--- a/gitignore.go
+++ b/gitignore.go
@@ -18,14 +18,14 @@ type segment struct {
 type pattern struct {
 	segments      []segment
 	negate        bool
-	dirOnly       bool   // trailing slash pattern or trailing /** pattern
-	hasConcrete   bool   // has at least one non-** segment
+	dirOnly       bool // trailing slash pattern or trailing /** pattern
+	hasConcrete   bool // has at least one non-** segment
 	anchored      bool
-	prefix        string // directory scope for nested .gitignore
-	text          string // original pattern text before compilation
-	source        string // file path this pattern came from, empty for programmatic
-	line          int    // 1-based line number in source file
-	literalSuffix string // fast-reject: last segment must end with this (e.g. ".log" from "*.log")
+	prefix        []string // directory scope segments for nested .gitignore
+	text          string   // original pattern text before compilation
+	source        string   // file path this pattern came from, empty for programmatic
+	line          int      // 1-based line number in source file
+	literalSuffix string   // fast-reject: last segment must end with this (e.g. ".log" from "*.log")
 }
 
 // Matcher checks paths against gitignore rules collected from .gitignore files,
@@ -220,12 +220,8 @@ func walkRecursive(root, rel string, m *Matcher, fn func(string, fs.DirEntry) er
 		if rel != "" {
 			entryRel = filepath.Join(rel, name)
 		}
-		matchPath := filepath.ToSlash(entryRel)
-		if entry.IsDir() {
-			matchPath += "/"
-		}
 
-		if m.Match(matchPath) {
+		if m.MatchPath(filepath.ToSlash(entryRel), entry.IsDir()) {
 			continue
 		}
 
@@ -349,17 +345,16 @@ func (m *Matcher) matchDetail(relPath string, isDir bool) MatchResult {
 // including the directory prefix scope and dirOnly handling.
 func matchPattern(p *pattern, pathSegs []string, isDir bool) bool {
 	segs := pathSegs
-	if p.prefix != "" {
-		prefixSegs := strings.Split(p.prefix, "/")
-		if len(segs) < len(prefixSegs) {
+	if len(p.prefix) > 0 {
+		if len(segs) < len(p.prefix) {
 			return false
 		}
-		for i, ps := range prefixSegs {
+		for i, ps := range p.prefix {
 			if segs[i] != ps {
 				return false
 			}
 		}
-		segs = segs[len(prefixSegs):]
+		segs = segs[len(p.prefix):]
 	}
 
 	if p.dirOnly {
@@ -433,7 +428,10 @@ func trimTrailingSpaces(s string) string {
 // Returns the compiled pattern and an empty string on success, or a zero
 // pattern and an error message on failure.
 func compilePattern(line, dir string) (pattern, string) {
-	p := pattern{prefix: dir}
+	var p pattern
+	if dir != "" {
+		p.prefix = strings.Split(dir, "/")
+	}
 
 	// Handle negation
 	if strings.HasPrefix(line, "!") {

--- a/gitignore.go
+++ b/gitignore.go
@@ -342,8 +342,8 @@ func (m *Matcher) matchDetail(relPath string, isDir bool) MatchResult {
 // including the directory prefix scope and dirOnly handling.
 func matchPattern(p *pattern, pathSegs []string, isDir bool) bool {
 	segs := pathSegs
-	if len(p.prefix) > 0 {
-		if len(segs) < len(p.prefix) {
+	if n := len(p.prefix); n > 0 {
+		if len(segs) < n {
 			return false
 		}
 		for i, ps := range p.prefix {
@@ -351,7 +351,7 @@ func matchPattern(p *pattern, pathSegs []string, isDir bool) bool {
 				return false
 			}
 		}
-		segs = segs[len(p.prefix):]
+		segs = segs[n:]
 	}
 
 	if p.dirOnly {

--- a/gitignore.go
+++ b/gitignore.go
@@ -197,10 +197,7 @@ func walkRecursive(root, rel string, m *Matcher, fn func(string, fs.DirEntry) er
 
 	// Load .gitignore for this directory before processing entries.
 	if rel != "" {
-		igPath := filepath.Join(dir, ".gitignore")
-		if _, err := os.Stat(igPath); err == nil {
-			m.AddFromFile(igPath, filepath.ToSlash(rel))
-		}
+		m.AddFromFile(filepath.Join(dir, ".gitignore"), filepath.ToSlash(rel))
 	}
 
 	entries, err := os.ReadDir(dir)

--- a/gitignore_bench_test.go
+++ b/gitignore_bench_test.go
@@ -111,3 +111,46 @@ func BenchmarkMatchDeepPath(b *testing.B) {
 		m.Match("a/b/c/d/e/f/g/file.txt")
 	}
 }
+
+func BenchmarkMatchNestedPatterns(b *testing.B) {
+	m := benchMatcher(b, realisticPatterns())
+	for _, dir := range []string{"src", "src/pkg", "src/pkg/internal", "src/pkg/internal/util"} {
+		m.AddPatterns([]byte("*.gen.go\nlocal/\n*.tmp\n"), dir)
+	}
+	b.ResetTimer()
+	for b.Loop() {
+		m.Match("src/pkg/internal/util/main.go")
+	}
+}
+
+func BenchmarkWalk(b *testing.B) {
+	b.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+
+	root := b.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".git", "info"), 0755); err != nil {
+		b.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(realisticPatterns()), 0644); err != nil {
+		b.Fatal(err)
+	}
+	for i := range 10 {
+		dir := filepath.Join(root, fmt.Sprintf("d%d", i))
+		for j := range 5 {
+			sub := filepath.Join(dir, fmt.Sprintf("s%d", j))
+			if err := os.MkdirAll(sub, 0755); err != nil {
+				b.Fatal(err)
+			}
+			for _, name := range []string{"a.go", "b.go", "c.log", "d.tmp"} {
+				if err := os.WriteFile(filepath.Join(sub, name), []byte("x"), 0644); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	}
+	b.ResetTimer()
+	for b.Loop() {
+		_ = gitignore.Walk(root, func(path string, d os.DirEntry) error {
+			return nil
+		})
+	}
+}


### PR DESCRIPTION
Three small allocation reductions on the match path, raised by @seh while reviewing #10.

`matchPattern` was calling `strings.Split(p.prefix, "/")` on every invocation for patterns that came from a nested `.gitignore`. The prefix never changes after compilation, so `compilePattern` now splits it once and stores the segments on the `pattern` struct.

`walkRecursive` was building a match path with a trailing `/` for directory entries and calling `Match`, which then strips the slash off again. It now calls `MatchPath` with `entry.IsDir()` directly and skips the concatenation.

`walkRecursive` was also calling `os.Stat` on each directory's `.gitignore` before `AddFromFile`, but `AddFromFile` already handles a missing file by returning early on the `os.ReadFile` error. Dropping the guard saves a syscall per directory walked.

Added `BenchmarkMatchNestedPatterns` and `BenchmarkWalk` to cover these paths. On an M1 Pro:

```
BenchmarkMatchNestedPatterns  6563 ns  560 B  13 allocs  ->  5244 ns  80 B  1 alloc
BenchmarkWalk                 2402 allocs                ->  2282 allocs
```

The existing match benchmarks also dropped a bit (around 10%) though those have no prefixed patterns so that may partly be noise.